### PR TITLE
fix FLOP/s calculation for OpenMP

### DIFF
--- a/openmp/bude.c
+++ b/openmp/bude.c
@@ -303,10 +303,10 @@ void printTimings(double start, double end)
 
   // Compute FLOP/s
   double ops_per_wg = WGSIZE*27 +
-                      params.natlig * (
+                      (long)params.natlig * (
                         2 +
                         WGSIZE*18 +
-                        params.natpro * (10 + WGSIZE*30)
+                        (long)params.natpro * (10 + WGSIZE*30)
                         ) +
                       WGSIZE;
   double total_ops  = ops_per_wg * (params.nposes/WGSIZE);


### PR DESCRIPTION
The GFLOP/s calculation in `printTimings()` for the OpenMP implementation was reporting incorrect (negative) values for large inputs, due to overflow. Computing `ops_per_wg` using long (rather than 32-bit) ints fixes the problem.

To test, run e.g.
```
./bude --deck ../data/bm2
```
before this change, miniBUDE reported:
```
...
Running C/OpenMP
- Total time:     30353.730 ms
- Average time:   3794.216 ms
- Interactions/s: 123.319 billion
- GFLOP/s:        -61.996
- GFInst/s:       3082.980
```
after the change, it reports:
```
Running C/OpenMP
- Total time:     30727.736 ms
- Average time:   3840.967 ms
- Interactions/s: 121.818 billion
- GFLOP/s:        3660.127
- GFInst/s:       3045.456
```
