### PR TITLE
Modifications to avoid including "gflop/s" in the "best gflop/s" computation if the validation fails

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -388,9 +388,15 @@ std::pair<double, std::vector<size_t>> validate(const Sample &sample, const Para
     }
     // flush at the end to make sure errors are clumped together
     std::cerr << std::flush;
+    return {valid, maxDiffPct, s, SummaryStats<double>({ std::numeric_limits<double>::max() }), 0, 0, 0};
   }
+  else if( !valid)
+    return {valid, maxDiffPct, s, SummaryStats<double>({ std::numeric_limits<double>::max() }), 0, 0, 0};
+  else {
+      return {valid, maxDiffPct, s, SummaryStats<double>(msWithoutWarmup), gflops, gfinsts, interactions_per_sec};
+    }
 
-  return {valid, maxDiffPct, s, SummaryStats<double>(msWithoutWarmup), gflops, gfinsts, interactions_per_sec};
+
 }
 
 [[nodiscard]] std::pair<int, std::string> selectDevice(const std::string &needle,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,11 +5,11 @@
 #include <string>
 #include <vector>
 
-#include <fstream>
-#include <sstream>
-#include <functional>
 #include <algorithm>
+#include <fstream>
+#include <functional>
 #include <iostream>
+#include <sstream>
 #include <unordered_map>
 
 #include "bude.h"
@@ -27,8 +27,7 @@
 #endif
 
 #ifndef MINIBUDE_COMPILE_COMMANDS
-  #define MINIBUDE_COMPILE_COMMANDS                                                                                    \
-    { MINIBUDE_WARN_NOT_CMAKE }
+  #define MINIBUDE_COMPILE_COMMANDS {MINIBUDE_WARN_NOT_CMAKE}
 #endif
 
 #ifdef USE_CPU_FEATURES
@@ -388,15 +387,12 @@ std::pair<double, std::vector<size_t>> validate(const Sample &sample, const Para
     }
     // flush at the end to make sure errors are clumped together
     std::cerr << std::flush;
-    return {valid, maxDiffPct, s, SummaryStats<double>({ std::numeric_limits<double>::max() }), 0, 0, 0};
-  }
-  else if( !valid)
-    return {valid, maxDiffPct, s, SummaryStats<double>({ std::numeric_limits<double>::max() }), 0, 0, 0};
+    return {valid, maxDiffPct, s, SummaryStats<double>({std::numeric_limits<double>::max()}), 0, 0, 0};
+  } else if (!valid)
+    return {valid, maxDiffPct, s, SummaryStats<double>({std::numeric_limits<double>::max()}), 0, 0, 0};
   else {
-      return {valid, maxDiffPct, s, SummaryStats<double>(msWithoutWarmup), gflops, gfinsts, interactions_per_sec};
-    }
-
-
+    return {valid, maxDiffPct, s, SummaryStats<double>(msWithoutWarmup), gflops, gfinsts, interactions_per_sec};
+  }
 }
 
 [[nodiscard]] std::pair<int, std::string> selectDevice(const std::string &needle,


### PR DESCRIPTION
This is to fix the issue mentioned in https://github.com/UoB-HPC/miniBUDE/issues/37. 

Currently, if the result is not valid, it will still print a result and so the "best gflop/s" which is determined could be incorrect. In particular, if the CUDA kernel launch fails, the "best gflop/s" will be too big since the kernel time was very fast since the kernel didn't run. This will cause the "best flop/s" to be based on an invalid run.

This PR avoids the problem above. If the validation fails, it sets the kernel time to the biggest possible, so that it will not be considered in the computation of "best" gflop/s. There are probably cleaner ways, this is just what I was using to get it working. I'm happy to make changes if requested!